### PR TITLE
Intial version (V3) of channel exporter uploaded

### DIFF
--- a/MS_Teams_Chat_Exporter/Constants/AppSettingsConstants.cs
+++ b/MS_Teams_Chat_Exporter/Constants/AppSettingsConstants.cs
@@ -1,4 +1,29 @@
-﻿using System;
+﻿/*
+TODO:
+- check attachments/etc --> image from HTML?
+- TEST: ignore conversations with threadProperties":       "isdeleted": "True",
+- adapt pdf creator for other types
+- PDF-Creation reactions from chats 
+
+DONE 31.10.
+- Remove space for conversations file namespace
+- check for other thread title
+- export also multiperson chats
+- export other teams channels
+
+DONE 1.11.
+- create PDF for all
+- Added final Trim for filenames --> avoid spaces on filenames end/beginning
+- allow pdfs to be done separately
+- add log --> exportlog.txt and move old logs to -x
+- remove no links if empty
+- PDF-Creation: handled ThreadActivity/AddMember as short text
+- PDF-Creation:  ThreadActivity/DeleteMember ignore
+- add name of person guess to oneToOne chats + identify yourself (from id and name)
+- add exit option if files are there and no parameter given
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -10,14 +35,30 @@ namespace MS_Teams_Chat_Exporter.Constants
     {
       public const string InitialApiUrl = "https://teams.microsoft.com/api/chatsvc/emea/v1/users/ME/conversations";
 
-      public const string DataFolderName = "data";
+      public const string TestApiUrl = "https://teams.microsoft.com/api/chatsvc/emea/v1/users/ME/conversations";
+
+      public const string DataFolderName = "export";		// base folder
+
+      public const string TestFolderName = "test";
 
       public const string MessageFolderName = "messages";
+      public const string ChannelFolderName = "channel";
+      public const string MultiFolderName = "chats";
 
-      public const string ExportPdfFolderName = "exports";
+      public const string ExportPdfFolderName = "pdf";
 
-      public const string ConversationJsonFileName = "conversations.json";
+      public const string ConversationJsonFileName = "conversations";
+
+      public const string BearerTokenFileName = "bt.txt";
 
       public const string OneToOnePersonelChatsKey = "@unq.gbl.spaces";
+      public const string TeamsaChannelChatsKey = "@thread.skype";
+      public const string TeamsStdChannelChatsKey = "@thread.tacv2";
+      public const string MultiChatsKey = "@thread.v2";
+      public const string AnnotationsChatsKey = ":annotations";
+      public const string MeChatKey = "48:notes";
+	  
+	 
+	  // Also: @thread.tacv2
     }
 }

--- a/MS_Teams_Chat_Exporter/Data/DataProcessor.cs
+++ b/MS_Teams_Chat_Exporter/Data/DataProcessor.cs
@@ -5,14 +5,57 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http.Headers;
 using System.Text;
-using System.Threading.Tasks;
+using System.Text.RegularExpressions;using System.Threading.Tasks;
 using MS_Teams_Chat_Exporter.Constants;
+using MS_Teams_Chat_Exporter.Utils;
+
+
 
 namespace MS_Teams_Chat_Exporter.Data
 {
     public static class DataProcessor
     {
-        public static async Task FetchAPIData(string initialApiUrl, string outputFilePath, string bearerToken, string directoryPath, string key)
+        public static bool stopIt = false;
+		
+        public static StreamWriter logwriter;
+		
+
+		public static void logWriteLine( string logline ) 
+		{
+			Console.WriteLine( logline );
+			 if (logwriter is not null) {
+				 logwriter.WriteLine( $"{DateTime.Now.ToLongTimeString()} : {logline}" );
+				 logwriter.Flush();
+			 }
+			
+		}
+
+		public static string createFileName( string basepath, string basename, string baseext, bool doIndex )
+		{
+			string basefilename = Path.Combine(basepath, basename).Trim();
+			baseext = baseext.Trim();
+			
+			if ( doIndex ) {
+				int i = 0;
+				string nextfile = basefilename;
+				while ( File.Exists( nextfile+baseext ) ) {
+					i = i+1;
+					nextfile = basefilename + "-" + i.ToString().Trim();
+				}
+				basefilename = nextfile;
+			}
+			return basefilename+baseext;
+			
+		}
+
+		
+		/******************************************************************************************/
+		/******************************************************************************************/
+		/*****                   FETCHAPIDATA                                                 *****/
+		/******************************************************************************************/
+		/******************************************************************************************/
+		
+		public static async Task FetchAPIData(string initialApiUrl, string outputFilePath, string bearerTokenFile, string directoryPath, string key)
         {
             try
             {
@@ -20,10 +63,17 @@ namespace MS_Teams_Chat_Exporter.Data
                 Directory.CreateDirectory(directoryPath);
 
                 var allConversations = new JArray();
+                var allResponses = new JArray();
                 string syncStateUrl = null;
                 int retryCount = 0;
-                const int maxRetries = 5;
-
+                const int maxRetries = 8;
+				
+				string bearerToken = "";
+				if (File.Exists(bearerTokenFile)) {
+                    // Read the JSON file into a string
+                    bearerToken = File.ReadAllText(bearerTokenFile);				
+				}
+				
                 using (HttpClient client = new HttpClient())
                 {
                     // Add the Bearer token to the request headers
@@ -33,6 +83,25 @@ namespace MS_Teams_Chat_Exporter.Data
 
                     while (!string.IsNullOrEmpty(currentApiUrl))
                     {
+						if ( string.IsNullOrEmpty(bearerToken) ) {
+							while ( string.IsNullOrEmpty(bearerToken) ) {
+								logWriteLine("");
+								logWriteLine(">>>>>>>>>>> !!!!! <<<<<<<<<<<<< ");
+								logWriteLine("Please enter your Bearer token to fetch your teams conversations (or No): ");
+								bearerToken = Console.ReadLine();
+							}
+							
+							if (  bearerToken.ToLower() == "no" ) {
+								logWriteLine("Exiting...");
+								stopIt = true;
+								break;
+							}
+							
+							await File.WriteAllTextAsync(bearerTokenFile, bearerToken);
+							client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
+							logWriteLine($"... continuing ...");
+						}
+
                         try
                         {
                             // Send GET request to the API
@@ -44,13 +113,26 @@ namespace MS_Teams_Chat_Exporter.Data
                                 string data = await response.Content.ReadAsStringAsync();
                                 JObject jsonResponse = JObject.Parse(data);
 
-                                // Extract and accumulate conversations
-                                var conversations = jsonResponse[key] as JArray;
-                                if (conversations != null)
-                                {
-                                    allConversations.Merge(conversations);
-                                }
-
+								if ( string.IsNullOrEmpty(key) ) 
+								{
+                                    logWriteLine("Add full json response");
+										allConversations.Add(jsonResponse);
+/* 									// Write all accumulated conversations to a JSON file
+									string json2Formatted = JsonConvert.SerializeObject(jsonResponse, Formatting.Indented);
+									await File.WriteAllTextAsync(outputFilePath, json2Formatted);
+                                    logWriteLine("DONE Write full json response");
+									currentApiUrl = null;
+ */								}
+								else
+								{
+									// Extract and accumulate conversations
+									var conversations = jsonResponse[key] as JArray;
+									if (conversations != null)
+									{
+										allConversations.Merge(conversations);
+									}
+								}
+								
                                 // Save the syncState URL if it's the first request
                                 if (syncStateUrl == null)
                                 {
@@ -73,22 +155,31 @@ namespace MS_Teams_Chat_Exporter.Data
                                 retryCount++;
                                 if (retryCount > maxRetries)
                                 {
-                                    Console.WriteLine("Max retry attempts reached. Exiting...");
+                                    logWriteLine("Max retry attempts reached. Exiting...");
                                     break;
                                 }
                                 int delay = (int)Math.Pow(2, retryCount) * 1000; // Exponential backoff
-                                Console.WriteLine($"Rate limit exceeded. Waiting for {delay / 1000} seconds before retrying...");
-                                await Task.Delay(delay);
+                                logWriteLine($"Rate limit exceeded. Waiting for {delay / 1000} seconds before retrying...");
+                                await Task.Delay(Math.Min(delay,64000));
                             }
+
+                            else if (response.StatusCode == (System.Net.HttpStatusCode)401) // UNauthorized
+                            {
+								// get new bearer token
+								bearerToken = "";
+                                logWriteLine($"Bearer token expired getting a new one");
+								await File.WriteAllTextAsync(bearerTokenFile, bearerToken);
+                            }
+
                             else
                             {
-                                Console.WriteLine($"Error: {response.StatusCode}");
+                                logWriteLine($"Error: {response.StatusCode}");
                                 break;
                             }
                         }
                         catch (Exception ex)
                         {
-                            Console.WriteLine($"An error occurred: {ex.Message}");
+                            logWriteLine($"An error occurred: {ex.Message}");
                             break;
                         }
 
@@ -98,60 +189,249 @@ namespace MS_Teams_Chat_Exporter.Data
 
                     // Write all accumulated conversations to a JSON file
                     string jsonFormatted = JsonConvert.SerializeObject(allConversations, Formatting.Indented);
+					
                     await File.WriteAllTextAsync(outputFilePath, jsonFormatted);
 
-                    Console.WriteLine($"Data has been written to {outputFilePath}");
+                    logWriteLine($"Data has been written to {outputFilePath}");
                 }
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"An error occurred: {ex.Message}");
+                logWriteLine($"An error occurred: {ex.Message}");
             }
         }
 
-        public static async Task GenerateMessageJson(string filePath, string bearerToken)
+		/******************************************************************************************/
+		/******************************************************************************************/
+		/*****                   GENERATEMESSAGEJSON                                          *****/
+		/******************************************************************************************/
+		/******************************************************************************************/
+
+        public static async Task GenerateMessageJson(string inputFile, string outPath, string bearerTokenFile)
         {
             try
             {
-                if (File.Exists(filePath))
+                if (File.Exists(inputFile))
                 {
                     // Read the JSON file into a string
-                    string jsonData = File.ReadAllText(filePath);
+                    string jsonData = File.ReadAllText(inputFile);
 
                     // Parse the JSON data into a JArray
                     JArray conversations = JArray.Parse(jsonData);
 
-                    // Loop through each conversation item
+					string messageDirectoryPath = Path.Combine(outPath, AppSettingsConstants.MessageFolderName);
+					Directory.CreateDirectory(messageDirectoryPath);
+
+					string channelDirectoryPath = Path.Combine(outPath, AppSettingsConstants.ChannelFolderName);
+					Directory.CreateDirectory(channelDirectoryPath);
+
+					string multiDirectoryPath = Path.Combine(outPath, AppSettingsConstants.MultiFolderName);
+					Directory.CreateDirectory(multiDirectoryPath);
+
+					string regSearch = new string(Path.GetInvalidFileNameChars());
+					Regex rg = new Regex(string.Format("[{0}]", Regex.Escape(regSearch)));
+
+
+					String mename = "";
+					String mefrom = "";
+					
+					// initial loop to find name and id of current user
                     foreach (JObject conversation in conversations)
                     {
+						string deleted =  conversation["threadProperties"]?["isdeleted"]?.ToString().Trim();
+						if ( ( ! string.IsNullOrEmpty( deleted ) ) && ( deleted == "True" ) ) {
+							continue;
+						}
+						
                         // Extract and print various properties
                         string execute = conversation["id"]?.ToString();
 
-                        // Export only one to one Chat
-                        if (execute.EndsWith(AppSettingsConstants.OneToOnePersonelChatsKey))
+						if ( execute == AppSettingsConstants.MeChatKey ) {
+							if ( mename != "" ) {
+								logWriteLine("");
+								logWriteLine(">>>>>>>>>>> !!!!! <<<<<<<<<<<<< ");
+								logWriteLine($"ERROR Duplicate identity found: {conversation["lastMessage"]?["imdisplayname"]?.ToString()} - From: {conversation["lastMessage"]?["from"]?.ToString()}");
+								logWriteLine("");
+								return;
+							}
+							mename = conversation["lastMessage"]?["imdisplayname"]?.ToString();
+							mefrom = conversation["lastMessage"]?["from"]?.ToString();
+							logWriteLine("");
+							logWriteLine("Name and Identity found ");
+                            logWriteLine($"Name          : {mename}");
+                            logWriteLine($"ID URL (from) : {mefrom}");
+							logWriteLine("");
+						}
+
+					}
+					
+                    // Loop through each conversation item
+                    foreach (JObject conversation in conversations)
+                    {
+						string deleted =  conversation["threadProperties"]?["isdeleted"]?.ToString().Trim();
+						if ( ( ! string.IsNullOrEmpty( deleted ) ) && ( deleted == "True" ) ) {
+							continue;
+						}
+						
+                        // Extract and print various properties
+                        string execute = conversation["id"]?.ToString();
+
+						string type =  conversation["threadProperties"]?["productThreadType"]?.ToString().Trim();
+						if ( string.IsNullOrEmpty( type ) ) {
+							type = conversation["type"]?.ToString().Trim();
+						}
+
+                        // Export one to one Chat and me chat
+                        if ( (execute.EndsWith(AppSettingsConstants.OneToOnePersonelChatsKey)) || (execute.EndsWith(AppSettingsConstants.MeChatKey)) )
                         {
-                            string id = conversation["threadProperties"]?["spaceThreadTopic"]?.ToString() + " " + conversation["version"]?.ToString();
-                            string type = conversation["type"]?.ToString();
+                            string top = conversation["threadProperties"]?["spaceThreadTopic"]?.ToString().Trim();
+							if ( string.IsNullOrEmpty( top ) ) {
+								top = conversation["threadProperties"]?["topicThreadTopic"]?.ToString().Trim();
+							}
+
+							// try to guess name of onetoone chat partner if last message is not from me - special case me chat
+                            string lfrom = conversation["lastMessage"]?["from"]?.ToString().Trim();
+							if ( string.IsNullOrEmpty( top ) ) {
+								if ( ( ! string.IsNullOrEmpty( lfrom ) ) && ( ( lfrom != mefrom ) || (execute.EndsWith(AppSettingsConstants.MeChatKey)) ) )  {
+									top = conversation["lastMessage"]?["imdisplayname"]?.ToString().Trim();
+								}
+							}
+							
+							if ( string.IsNullOrEmpty( top ) ) {
+								top = " " + "ID: " + conversation["version"]?.ToString().Trim();
+							} else {
+								top = top + " (ID: " + conversation["version"]?.ToString().Trim() + ")";
+							}
+							top = rg.Replace(top, "").Trim();
+
                             string messageAPIURL = conversation["messages"]?.ToString();
-                            Console.WriteLine($"Conversation ID: {id} - Type: {type}");
+                            logWriteLine($"Conversation O2O ID: {top} - Type: {type}");
 
-                            string messageDirectoryPath = Path.Combine(Directory.GetCurrentDirectory(), AppSettingsConstants.MessageFolderName);
-                            string messageOutputFilePath = Path.Combine(messageDirectoryPath, $"{id}.json");
+                            string messageOutputFilePath = createFileName( messageDirectoryPath, top, ".json", true );
 
-                            await FetchAPIData(messageAPIURL, messageOutputFilePath, bearerToken, messageDirectoryPath, AppSettingsConstants.MessageFolderName);
+                            await FetchAPIData(messageAPIURL, messageOutputFilePath, bearerTokenFile, messageDirectoryPath, "messages" );
                             await Task.Delay(1000);
                         }
+/* */
+                        // Export also OLD Teams & Channels
+                        else if ( (execute.EndsWith(AppSettingsConstants.TeamsaChannelChatsKey) || (execute.EndsWith(AppSettingsConstants.AnnotationsChatsKey)) || (execute.EndsWith(AppSettingsConstants.TeamsStdChannelChatsKey))) ) 
+                        {
+                            string top = conversation["threadProperties"]?["spaceThreadTopic"]?.ToString().Trim();
+							if ( string.IsNullOrEmpty( top ) ) {
+								top = conversation["threadProperties"]?["topicThreadTopic"]?.ToString().Trim();
+							}
+
+							if ( string.IsNullOrEmpty( top ) ) {
+								top = " " + type + " ID: " + conversation["version"]?.ToString().Trim();
+							} else {
+								top = top + " (" + type + " ID: " + conversation["version"]?.ToString().Trim() + ")";
+							}
+							top = rg.Replace(top, "").Trim();
+
+                            string messageAPIURL = conversation["messages"]?.ToString();
+                            logWriteLine($"Conversation TCA ID: {top} - Type: {type}");
+
+                            string channelOutputFilePath = createFileName( channelDirectoryPath, top, ".json", true );
+
+                            await FetchAPIData(messageAPIURL, channelOutputFilePath, bearerTokenFile, channelDirectoryPath, "messages" );
+// getting full JSON                            await FetchAPIData(messageAPIURL, channelOutputFilePath, bearerTokenFile, channelDirectoryPath, "");
+                            await Task.Delay(1000);
+                        }
+                        // Export also OLD Teams & Channels
+                        else if (execute.EndsWith(AppSettingsConstants.MultiChatsKey))
+                        {
+                            string top = conversation["threadProperties"]?["topic"]?.ToString().Trim();
+							if ( string.IsNullOrEmpty( top ) ) {
+								top = type + " ID: " + conversation["version"]?.ToString().Trim();
+							} else {
+								top = top + " (" + type + " ID: " + conversation["version"]?.ToString().Trim() + ")";
+							}
+							top = rg.Replace(top, "").Trim();
+
+                            string messageAPIURL = conversation["messages"]?.ToString();
+                            logWriteLine($"Conversation Mul ID: {top} - Type: {type}");
+
+                            string multiOutputFilePath = createFileName( multiDirectoryPath, top, ".json", true );
+
+                            await FetchAPIData(messageAPIURL, multiOutputFilePath, bearerTokenFile, multiDirectoryPath, "messages" );
+                            await Task.Delay(1000);
+                        } else {
+                            string version = conversation["version"]?.ToString().Trim();
+							logWriteLine("");
+							logWriteLine(">>>>>>>>>>> !!!!! <<<<<<<<<<<<< ");
+                            logWriteLine($"IGNORED UNKNOWN Conversation Version: {version} - Type: {execute}");
+							logWriteLine("");
+						}
+						
+						if ( stopIt ) {
+							break;
+						}
                     }
                 }
                 else
                 {
-                    Console.WriteLine($"File not found: {filePath}");
+                    logWriteLine($"File not found: {inputFile}");
                 }
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"An error occurred: {ex.Message}");
+                logWriteLine($"An error occurred: {ex.Message}");
             }
         }
+		
+		
+		/******************************************************************************************/
+		/******************************************************************************************/
+		/*****                   PDF                                                          *****/
+		/******************************************************************************************/
+		/******************************************************************************************/
+
+        public static async Task GeneratePdf(string outPath, string subdir)
+        {
+			if ( stopIt ) {
+				return;
+			}
+            try
+            {
+				string destdir = subdir.Trim() + "-" + AppSettingsConstants.ExportPdfFolderName;
+				string sourcePath = Path.Combine(outPath, subdir);
+				 // Create the directory if it does not exist
+			   if (Directory.Exists(sourcePath))
+				{
+					string[] files = Directory.GetFiles(sourcePath);
+
+					// Output the paths of the files
+					logWriteLine("Files in directory: " + sourcePath);
+
+					foreach (var file in files)
+					{
+						PrintPDF.GeneratePDFFromJSON(file, Path.Combine(outPath, destdir));
+					}
+				}
+				else
+				{
+					logWriteLine("Error -  Directory not found : " + sourcePath );
+					await Task.Delay(1000);
+				}
+			}
+			catch (Exception ex)
+			{
+				logWriteLine($"An error occurred: {ex.Message}");
+			}
+
+			// Small delay to prevent hammering the API too quickly
+			await Task.Delay(200);
+		}
+
+        public static async Task doPdf(string directoryPath) {
+			await DataProcessor.GeneratePdf( directoryPath, AppSettingsConstants.MessageFolderName );
+
+			await DataProcessor.GeneratePdf( directoryPath, AppSettingsConstants.ChannelFolderName );
+
+			await DataProcessor.GeneratePdf( directoryPath, AppSettingsConstants.MultiFolderName );
+
+				
+		}
+
     }
 }

--- a/MS_Teams_Chat_Exporter/Program.cs
+++ b/MS_Teams_Chat_Exporter/Program.cs
@@ -5,10 +5,54 @@ namespace MS_Teams_Chat_Exporter
 {
     class Program
     {
+		// options cmd
+		
+		
         static async Task Main(string[] args)
         {
+			String argcmd = "";
+			
+			bool doPdf = true;
+			bool doConv = true;
+			bool doChats = true;
+			bool doCont = false;
+			
+			if (args.Length > 0) {
+				argcmd = args[0];
+			}
+			
+			if ( argcmd == "pdf" ) {
+				doConv = false;
+				doChats = false;
+			} else if ( argcmd == "nopdf" ) {
+				doPdf = false;
+			} else if ( argcmd == "cont" ) {
+				doCont = true;
+				doPdf = false;
+			} else if ( argcmd == "" ) {
+			} else {
+				Console.WriteLine("");
+				Console.WriteLine("MS_Teams_Enterprise_Channel_Exporter - V3");
+				Console.WriteLine("-> JVI & MrSk007");
+				Console.WriteLine("");
+				Console.WriteLine("dotnet run [ <cmd> ]");
+				Console.WriteLine("");
+				Console.WriteLine("without cmd all elements are executed: retrieve last conversations - get the corresponding chats - create pdfs");
+				Console.WriteLine("");
+				Console.WriteLine("following cmds are supported");
+				Console.WriteLine(" cont  : continue last run use conversations file if existing");
+				Console.WriteLine(" cont  : continue last run use conversations file if existing - without pdf");
+				Console.WriteLine(" pdf   : only create pdf from existing chats");
+				Console.WriteLine(" nopdf : run normally but no pdf creation");
+				Console.WriteLine("");
+				Console.WriteLine("console log copy can be found in exportlog.txt");
+				Console.WriteLine("");
+				return;
+				
+			}
+			
             ICoreProcessor _coreProcessor = new CoreProcessor();
-            await _coreProcessor.Start();
+            await _coreProcessor.Start(argcmd, doPdf, doConv, doChats, doCont);
         }
     }
 }

--- a/MS_Teams_Chat_Exporter/Utils/PrintAppTilte.cs
+++ b/MS_Teams_Chat_Exporter/Utils/PrintAppTilte.cs
@@ -9,7 +9,7 @@ namespace MS_Teams_Chat_Exporter.Utils
         public static void PrintColorFullTitle()
         {
             Figlet figlet = new Figlet();
-            Console.WriteLine(figlet.ToAscii("Author : MrSk007"));
+            Console.WriteLine(figlet.ToAscii("A: MrSk007 + JVI"));
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,9 +1,19 @@
-# MS Teams Enterprise Chat Exporter
+# MS Teams Enterprise Chat Exporter - Channel exporter
 
 **MS Teams Enterprise Chat Exporter** is a C# console application that allows users to export their Microsoft Teams chat conversations to JSON and PDF formats. The application fetches chat data using the Microsoft Teams API and provides an option to generate PDFs from the exported JSON data.
 
-## Portable Exe for Windows x64
-[Download](https://drive.google.com/file/d/1hAADH03idRlmUO6fOG2L-CWcnHND6GD7/view?usp=sharing)
+Augmented
+- Include all chats available
+- Ignore deleted chats
+- All output files collected under export directory
+- exportlog.txt added (and preserved on further runs)
+- added options to restart and also partial runs (like pdf / no pdf)
+- Ask again for bearer token when expired
+
+OPEN:
+- Attachments and Images - requires different authentication?
+- PDF generator not working for all types of chats
+
 
 ## Features
 
@@ -34,6 +44,12 @@ Enter your Bearer token when prompted.
 The application will fetch your conversations and save them in a conversations.json file.
 
 You can choose to generate PDFs from the fetched chat data. If you opt for this, PDFs will be saved in the exports directory.
+
+## Command line options
+
+- **cont** continue last run
+- **pdf** create only pdf from existing json files 
+- **nopdf** create only json files no pdf 
 
 ## Code Structure
 


### PR DESCRIPTION
Initial implementation of extension to also export channels, multi person chats & meeting chats.
Additionally:
- Rerequesting token for athentication after expiry
- Changed directories to collect all exports separately - export
-  Ignore deleted chats
-  All output files collected under export directory
-  exportlog.txt added (and preserved on further runs)
-  cmdline: added options to restart and also partial runs (like pdf / no pdf)

Open:
PDF-Exporter not yet full adapted